### PR TITLE
Add pytest and initial unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@ You will be asked for your username and joined date the first time you run the p
 ![firstrun](/docs/lastavgscreen1.png?raw=true "lastavg firstrun")
 Here's how the output looks like:
 ![output](/docs/lastavgscreen.png?raw=true "lastavg output")
+
+## Running tests
+After installing the dependencies listed in `requirements.txt`, run:
+```
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 lxml
 requests
+
+pytest

--- a/tests/test_lastavg.py
+++ b/tests/test_lastavg.py
@@ -1,0 +1,27 @@
+import importlib.util
+import time
+from datetime import datetime
+from pathlib import Path
+
+# Load lastavg module from file
+spec = importlib.util.spec_from_file_location(
+    "lastavg", str(Path(__file__).resolve().parents[1] / "lastavg.py")
+)
+lastavg = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(lastavg)
+
+
+def test_joineddate(tmp_path, monkeypatch):
+    temp_home = tmp_path
+    config_dir = temp_home / ".config" / "lastavg"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "config.cfg"
+    config_path.write_text("[DEFAULT]\nuser=testuser\njoined=01.01.2020\n")
+
+    monkeypatch.setattr(lastavg, "HOME", str(temp_home))
+
+    expected = (
+        datetime.strptime(time.strftime("%d.%m.%Y"), "%d.%m.%Y")
+        - datetime.strptime("01.01.2020", "%d.%m.%Y")
+    ).days + 1
+    assert lastavg.joineddate() == expected


### PR DESCRIPTION
## Summary
- introduce `pytest` dependency and document how to run the tests
- add unit test for `joineddate()` using a temporary configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846c1e715508326a7dfb64572bb300e